### PR TITLE
Change eth_chainId for Ethereum Mainnet to 0x1

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DefaultEthereumMethods.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DefaultEthereumMethods.kt
@@ -134,7 +134,7 @@ class DefaultEthereumMethods(
             "eth_chainId" -> {
                 when {
                     Chain.ETHEREUM == chain -> {
-                        "\"0x0\""
+                        "\"0x1\""
                     }
                     Chain.ETHEREUM_CLASSIC == chain -> {
                         "\"0x3d\""

--- a/src/test/groovy/io/emeraldpay/dshackle/upstream/calls/DefaultEthereumMethodsSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/upstream/calls/DefaultEthereumMethodsSpec.groovy
@@ -19,7 +19,7 @@ class DefaultEthereumMethodsSpec extends Specification {
         new String(new DefaultEthereumMethods(chain).executeHardcoded("eth_chainId")) == id
         where:
         chain                  | id
-        Chain.ETHEREUM         | '"0x0"'
+        Chain.ETHEREUM         | '"0x1"'
         Chain.ETHEREUM_CLASSIC | '"0x3d"'
         Chain.TESTNET_KOVAN    | '"0x2a"'
         Chain.TESTNET_GOERLI    | '"0x5"'


### PR DESCRIPTION
Geth, Nethermind, and Parity return "0x1" when requesting `eth_chainId` from the node when running mainnet, not "0x0"

I even looked at Infura docs here: https://infura.io/docs/ethereum/json-rpc/eth-chainId