### PR TITLE
Add support for Fantom

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/startup/ConfiguredUpstreams.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/startup/ConfiguredUpstreams.kt
@@ -64,6 +64,8 @@ open class ConfiguredUpstreams(
             "eth" to Chain.ETHEREUM,
             "polygon" to Chain.MATIC,
             "matic" to Chain.MATIC,
+            "fantom" to Chain.FANTOM,
+            "opera" to Chain.FANTOM,
             "etc" to Chain.ETHEREUM_CLASSIC,
             "morden" to Chain.TESTNET_MORDEN,
             "kovan" to Chain.TESTNET_KOVAN,

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DefaultEthereumMethods.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/DefaultEthereumMethods.kt
@@ -122,6 +122,9 @@ class DefaultEthereumMethods(
                     Chain.MATIC == chain -> {
                         "\"137\""
                     }
+                    Chain.FANTOM == chain -> {
+                        "\"250\""
+                    }
                     Chain.TESTNET_MORDEN == chain -> {
                         "\"2\""
                     }
@@ -147,6 +150,9 @@ class DefaultEthereumMethods(
                     }
                     Chain.MATIC == chain -> {
                         "\"0x89\""
+                    }
+                    Chain.FANTOM == chain -> {
+                        "\"0xfa\""
                     }
                     Chain.TESTNET_ROPSTEN == chain -> {
                         "\"0x3\""


### PR DESCRIPTION
In a previous PR you added this:
`CHAIN_FANTOM = 102; // Fantom, https://fantom.foundation/`

But these lines were missing. Fantom calls their chain opera sometimes too, so I added opera as an option as well.
