### PR TITLE
allow configuring methods with static responses

### DIFF
--- a/docs/04-upstream-config.adoc
+++ b/docs/04-upstream-config.adoc
@@ -218,6 +218,25 @@ NOTE: It's especially useful when used together with upstream labels.If an archi
 possible to specify that the client wants to execute method `trace_transaction` only on an archive node(s), which has
 complete historical data for tracing.
 
+=== Static Methods
+
+You can overwrite existing methods or add new ones using a static response:
+
+[source, yaml]
+----
+upstreams:
+  - id: my-node
+    chain: ethereum
+    methods:
+      enabled:
+        - name: net_version
+          static: "100000"
+        - name: eth_custom_array
+          static: '["custom_array_response"]'
+        - name: eth_custom_bool
+          static: "false"
+----
+
 === Authentication
 
 ==== TLS

--- a/docs/04-upstream-config.adoc
+++ b/docs/04-upstream-config.adoc
@@ -230,7 +230,9 @@ upstreams:
     methods:
       enabled:
         - name: net_version
-          static: "100000"
+          static: "\"100000\""
+        - name: eth_chainId
+          static: "0x186a0"
         - name: eth_custom_array
           static: '["custom_array_response"]'
         - name: eth_custom_bool

--- a/src/main/kotlin/io/emeraldpay/dshackle/config/UpstreamsConfig.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/config/UpstreamsConfig.kt
@@ -173,6 +173,7 @@ open class UpstreamsConfig {
 
     class Method(
         val name: String,
-        val quorum: String? = null
+        val quorum: String? = null,
+        val static: String? = null
     )
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/config/UpstreamsConfigReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/config/UpstreamsConfigReader.kt
@@ -249,7 +249,8 @@ class UpstreamsConfigReader(
                 getValueAsString(m, "name")?.let { name ->
                     UpstreamsConfig.Method(
                         name = name,
-                        quorum = getValueAsString(m, "quorum")
+                        quorum = getValueAsString(m, "quorum"),
+                        static = getValueAsString(m, "static")
                     )
                 }
             }?.filterNotNull()?.toSet() ?: emptySet()

--- a/src/main/kotlin/io/emeraldpay/dshackle/startup/ConfiguredUpstreams.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/startup/ConfiguredUpstreams.kt
@@ -123,6 +123,9 @@ open class ConfiguredUpstreams(
                     if (m.quorum != null) {
                         it.setQuorum(m.name, m.quorum)
                     }
+                    if (m.static != null) {
+                        it.setStaticResponse(m.name, m.static)
+                    }
                 }
             }
         } else {

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/ManagedCallMethods.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/ManagedCallMethods.kt
@@ -44,6 +44,7 @@ class ManagedCallMethods(
         enabled + delegated - disabled
     )
     private val quorum: MutableMap<String, CallQuorum> = HashMap()
+    private val staticResponse: MutableMap<String, String> = HashMap()
 
     init {
         enabled.forEach { m ->
@@ -62,6 +63,10 @@ class ManagedCallMethods(
             }
         }
         this.quorum[method] = quorum
+    }
+
+    fun setStaticResponse(method: String, response: String) {
+        this.staticResponse[method] = response
     }
 
     override fun getQuorumFor(method: String): CallQuorum {
@@ -84,10 +89,14 @@ class ManagedCallMethods(
     }
 
     override fun isHardcoded(method: String): Boolean {
-        return delegate.isHardcoded(method)
+        return this.staticResponse.containsKey(method) || delegate.isHardcoded(method)
     }
 
     override fun executeHardcoded(method: String): ByteArray {
+        if (this.staticResponse.containsKey(method)) {
+            val json = "\"" + this.staticResponse[method] + "\""
+            return json.toByteArray()
+        }
         return delegate.executeHardcoded(method)
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/ManagedCallMethods.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/calls/ManagedCallMethods.kt
@@ -16,11 +16,13 @@
  */
 package io.emeraldpay.dshackle.upstream.calls
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.emeraldpay.dshackle.quorum.AlwaysQuorum
 import io.emeraldpay.dshackle.quorum.CallQuorum
 import io.emeraldpay.dshackle.quorum.NonEmptyQuorum
 import io.emeraldpay.dshackle.quorum.NotLaggingQuorum
 import org.slf4j.LoggerFactory
+import java.io.IOException
 import java.util.Collections
 
 /**
@@ -94,7 +96,15 @@ class ManagedCallMethods(
 
     override fun executeHardcoded(method: String): ByteArray {
         if (this.staticResponse.containsKey(method)) {
-            val json = "\"" + this.staticResponse[method] + "\""
+            var json: String = this.staticResponse[method].orEmpty()
+            // Check if it's valid JSON
+            val mapper = ObjectMapper()
+            try {
+                mapper.readTree(json)
+            } catch (e: IOException) {
+                // Encode and default to string
+                json = mapper.writeValueAsString(json)
+            }
             return json.toByteArray()
         }
         return delegate.executeHardcoded(method)


### PR DESCRIPTION
Haven't touched Java for 8 years. And I thought that I would be able to live without JDK on my machine, haha. This is also the first time I'm looking at Kotlin :see_no_evil: .. so bear with me. I'm not sure if I'm changing code at the right places, so any help is really appreciated! :) 

The idea would be that we could have static method responses via configuration. This could be a workaround for https://github.com/emeraldpay/dshackle/issues/96 

Example:

```yaml
# config
cluster:
  upstreams:
    - id: geth-0
      chain: ethereum
      methods:
        enabled:
          - name: eth_chainId
            static: "0x1467f3"  # static return value
          - name: net_version
            static: "1337331"  # static return value
 ...
```

