### PR TITLE
WIP: allow totalDifficulty to be the same

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/AbstractHead.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/AbstractHead.kt
@@ -46,7 +46,7 @@ abstract class AbstractHead : Head {
                 it.hash
             }.filter { block ->
                 val curr = head.get()
-                curr == null || curr.difficulty < block.difficulty
+                curr == null || curr.difficulty <= block.difficulty
             }
             .doFinally {
                 // close internal stream if upstream is finished, otherwise it gets stuck,
@@ -59,7 +59,7 @@ abstract class AbstractHead : Head {
             .subscribe { block ->
                 notifyBeforeBlock()
                 val prev = head.getAndUpdate { curr ->
-                    if (curr == null || curr.difficulty < block.difficulty) {
+                    if (curr == null || curr.difficulty <= block.difficulty) {
                         block
                     } else {
                         curr


### PR DESCRIPTION
this is a PR to discuss and progress to fix #132 
as a WIP/Draft currently as I am not sure about is the impact on non ethereum chains  - for our Ethereum case it seems to work fine cc @skylenet 

PS: maybe also one refactor would be nice - renaming difficulty to totalDifficulty - this really send me on the wrong track that the difficulty I saw not moving anymore and not being 0 was actually the totalDifficutly just named difficulty.