### PR TITLE
Preserve batch request-response correspondence

### DIFF
--- a/docs/reference-configuration.adoc
+++ b/docs/reference-configuration.adoc
@@ -51,6 +51,7 @@ proxy:
   host: 0.0.0.0
   port: 8080
   websocket: true
+  preserve-batch-order: false
   tls:
     enabled: true
     server:
@@ -352,6 +353,7 @@ health:
 proxy:
   host: 0.0.0.0
   port: 8080
+  preserve-batch-order: false
   tls:
     enabled: true
     server:
@@ -379,6 +381,10 @@ proxy:
 | `port`
 | `8080`
 | Port to bind HTT server
+
+| `port`
+| `false`
+| Should proxy preserve request-response correspondence when sending batch request via http
 
 | `websocket`
 | `true`

--- a/docs/reference-configuration.adoc
+++ b/docs/reference-configuration.adoc
@@ -395,6 +395,12 @@ proxy:
 | Setup TLS configuration for the Proxy server.
 See <<tls>> section
 
+| `preserve-batch-order`
+| false
+| If `false` Dshackle may produce _batch_ response in different order, which is correct as per JSON RPC Spec.
+If set to `true` then Dshackle preserves _batch_ order based on request order.
+Note that latter is ineffective and use this option only when a client cannot reference responses by their IDs.
+
 | `routes`
 |
 a| Routing paths for Proxy.

--- a/src/main/kotlin/io/emeraldpay/dshackle/config/ProxyConfig.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/config/ProxyConfig.kt
@@ -50,6 +50,11 @@ open class ProxyConfig {
      */
     var routes: List<Route> = ArrayList()
 
+    /**
+     * Should proxy preserve request-response correspondence when sending batch request via http
+     */
+    var preserveBatchOrder: Boolean = false
+
     class Route(
         /**
          * URL binding for the route. http://$host:$port/$id

--- a/src/main/kotlin/io/emeraldpay/dshackle/config/ProxyConfigReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/config/ProxyConfigReader.kt
@@ -61,6 +61,9 @@ class ProxyConfigReader : YamlConfigReader(), ConfigReader<ProxyConfig> {
         getValueAsBool(input, "websocket")?.let {
             config.websocketEnabled = it
         }
+        getValueAsBool(input, "preserve-batch-order")?.let {
+            config.preserveBatchOrder = it
+        }
         val currentRoutes = HashSet<String>()
         getList<MappingNode>(input, "routes")?.let { routes ->
             config.routes = routes.value.map { route ->

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/BaseHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/BaseHandler.kt
@@ -50,15 +50,19 @@ abstract class BaseHandler(
                 Mono.just("")
             }
         }
-        var jsons = execute(chain, call.items, handler)
+        val jsons = execute(chain, call.items, handler)
 
         return if (call.type == ProxyCall.RpcType.SINGLE) {
             jsons.transform(writeRpcJson.toJsons(call)).next()
         } else {
-            if (preserveBatchOrder) {
-                jsons = jsons.sort { a, b -> a.id.compareTo(b.id) }
-            }
             jsons
+                .let {
+                    if (preserveBatchOrder) {
+                        it.transform(reorderByRequest(call.items))
+                    } else {
+                        it
+                    }
+                }
                 .transform(writeRpcJson.toJsons(call))
                 .transform(writeRpcJson.asArray())
         }
@@ -95,5 +99,29 @@ abstract class BaseHandler(
                     requestMetrics.get(chain, item.method).failMetric.increment()
                 }
             }
+    }
+
+    /**
+     * Reorders responses to the original request order.
+     * Note that it's highly inefficient because it requires keeping all the responses in memory until last one is processes, so should be used only if
+     * a client is unable to reference responses by their IDs.
+     */
+    fun reorderByRequest(items: List<BlockchainOuterClass.NativeCallItem>): java.util.function.Function<Flux<NativeCall.CallResult>, Flux<NativeCall.CallResult>> {
+        val order = items.map { it.id }
+        return java.util.function.Function { src ->
+            src.collectList()
+                .map { results ->
+                    order.map { id ->
+                        results.find { it.id == id }
+                            // If Proxy is configured to preserve original order it means that a client expect responses at exact same position
+                            // as requests even if a request completely failed for a some reason. It's very unlikely situation, but still possible
+                            // At this case, if we found a gap in responses, we put a default response with an error
+                            ?: NativeCall.CallResult(id, null, NativeCall.CallError(id, "No response", null))
+                    }
+                }
+                .flatMapMany {
+                    Flux.fromIterable(it)
+                }
+        }
     }
 }

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/HttpHandler.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/HttpHandler.kt
@@ -37,6 +37,7 @@ import java.util.function.BiFunction
  * Responds to HTTP requests made to the Ethereum Proxy Server
  */
 class HttpHandler(
+    private val config: ProxyConfig,
     private val readRpcJson: ReadRpcJson,
     writeRpcJson: WriteRpcJson,
     nativeCall: NativeCall,
@@ -78,7 +79,7 @@ class HttpHandler(
                 requestMetrics.get(chain, "invalid_method").errorMetric.increment()
             }
             .flatMapMany { call ->
-                execute(chain, call, handler)
+                execute(chain, call, handler, config.preserveBatchOrder)
             }
             .onErrorResume(RpcException::class.java) { err ->
                 val id = err.details?.let {

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/ProxyCall.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/ProxyCall.kt
@@ -36,7 +36,7 @@ class ProxyCall(
     /**
      * Mapping from our internal ids to user provided JSON RPC ids.
      */
-    val ids = HashMap<Int, Any>()
+    val ids = ArrayList<Any>()
 
     /**
      * Content of the request

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/ProxyServer.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/ProxyServer.kt
@@ -80,7 +80,7 @@ class ProxyServer(
         StandardRequestMetrics()
     }
 
-    private val httpHandler = HttpHandler(readRpcJson, writeRpcJson, nativeCall, accessHandler, requestMetrics)
+    private val httpHandler = HttpHandler(config, readRpcJson, writeRpcJson, nativeCall, accessHandler, requestMetrics)
     private val wsHandler: WebsocketHandler? = if (config.websocketEnabled) {
         WebsocketHandler(readRpcJson, writeRpcJson, nativeCall, nativeSubscribe, accessHandler, requestMetrics)
     } else null

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/ReadRpcJson.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/ReadRpcJson.kt
@@ -165,10 +165,9 @@ open class ReadRpcJson : Function<ByteArray, ProxyCall> {
         var seq = seqStart
         return items
             .map { json ->
-                val id = seq++
-                context.ids[id] = json.id
+                context.ids.add(json.id)
                 BlockchainOuterClass.NativeCallItem.newBuilder()
-                    .setId(id)
+                    .setId(context.ids.size - 1)
                     .setMethod(json.method)
                     .setPayload(ByteString.copyFrom(objectMapper.writeValueAsBytes(json.params)))
                     .build()

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/WriteRpcJson.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/WriteRpcJson.kt
@@ -45,7 +45,7 @@ open class WriteRpcJson {
         return Function { flux ->
             flux
                 .flatMap { response ->
-                    if (!call.ids.containsKey(response.id)) {
+                    if (call.ids.size <= response.id) {
                         log.warn("ID wasn't requested: ${response.id}")
                         return@flatMap Flux.empty<String>()
                     }

--- a/src/test/groovy/io/emeraldpay/dshackle/config/ProxyConfigReaderSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/config/ProxyConfigReaderSpec.groovy
@@ -81,6 +81,7 @@ class ProxyConfigReaderSpec extends Specification {
         act.enabled
         act.host == '0.0.0.0'
         act.port == 8080
+        act.preserveBatchOrder
         act.routes.size() == 2
         with(act.routes[0]) {
             id == "ethereum"

--- a/src/test/groovy/io/emeraldpay/dshackle/proxy/HttpHandlerSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/proxy/HttpHandlerSpec.groovy
@@ -18,6 +18,7 @@ package io.emeraldpay.dshackle.proxy
 import com.google.protobuf.ByteString
 import io.emeraldpay.api.proto.BlockchainOuterClass
 import io.emeraldpay.api.proto.Common
+import io.emeraldpay.dshackle.config.ProxyConfig
 import io.emeraldpay.dshackle.monitoring.accesslog.AccessHandlerHttp
 import io.emeraldpay.dshackle.rpc.NativeCall
 import io.emeraldpay.dshackle.upstream.rpcclient.JsonRpcResponse
@@ -56,6 +57,7 @@ class HttpHandlerSpec extends Specification {
             _ * it.create(_,) >> accessHandler
         }
         def handler = new HttpHandler(
+                new ProxyConfig(),
                 new ReadRpcJson(), new WriteRpcJson(),
                 nativeCall, accessHandlerFactory, Stub(ProxyServer.RequestMetricsFactory)
         )
@@ -84,6 +86,7 @@ class HttpHandlerSpec extends Specification {
         }
 
         def handler = new HttpHandler(
+                new ProxyConfig(),
                 read, new WriteRpcJson(),
                 Stub(NativeCall), Stub(AccessHandlerHttp.HandlerFactory),
                 metrics
@@ -110,6 +113,7 @@ class HttpHandlerSpec extends Specification {
 
 
         def handler = new HttpHandler(
+                new ProxyConfig(),
                 new ReadRpcJson(), writeRpcJson,
                 nativeCall, Stub(AccessHandlerHttp.HandlerFactory), Stub(ProxyServer.RequestMetricsFactory)
         )
@@ -122,7 +126,7 @@ class HttpHandlerSpec extends Specification {
                         .build()
         )
         when:
-        def act = handler.execute(Chain.ETHEREUM, call, new AccessHandlerHttp.NoOpHandler())
+        def act = handler.execute(Chain.ETHEREUM, call, new AccessHandlerHttp.NoOpHandler(), false)
 
         then:
         1 * nativeCall.nativeCallResult(_) >> Flux.just(new NativeCall.CallResult(1, "".bytes, null))

--- a/src/test/resources/dshackle-proxy-max.yaml
+++ b/src/test/resources/dshackle-proxy-max.yaml
@@ -2,6 +2,7 @@ proxy:
   enabled: true
   host: 0.0.0.0
   port: 8080
+  preserve-batch-order: true
   routes:
     - id: ethereum
       blockchain: ethereum

--- a/testing/dshackle/dshackle-real.yaml
+++ b/testing/dshackle/dshackle-real.yaml
@@ -22,6 +22,7 @@ cache:
 
 proxy:
   port: 18081
+  preserve-batch-order: true
   tls:
     enabled: false
   routes:


### PR DESCRIPTION
Added option to preserve batch request-response correspondence order when making batch request via http.
Unfortunately, a lot of applications depend on this property, despite it not being a part of specification.
Thus, this option may provide better compatibility for those apps.

Option name is ```preserve-batch-order```, default is false. Example proxy config:
```yaml
proxy:
  port: 18081
  preserve-batch-order: true
  tls:
    enabled: false
  routes:
    - id: eth
      blockchain: ethereum
```

Example batch request on which dshackle shuffles reponse on master and preserves order in PR:
```bash
curl --location --request POST 'http://127.0.0.1:18081/eth' \
--header 'Content-Type: application/json' \
--data-raw '[
    {"jsonrpc":"2.0","method":"eth_chainId","params": [],"id":1},
    {"jsonrpc":"2.0","method":"eth_blockNumber","params": [],"id":2},
    {"jsonrpc":"2.0","method":"eth_chainId","params": [],"id":3}
]'
```

Expected output:
```json
[{"jsonrpc":"2.0","id":1,"result":"0x1"},{"jsonrpc":"2.0","id":2,"result":"0xdf21cc"},{"jsonrpc":"2.0","id":3,"result":"0x1"}]
```

