### PR TITLE
Preflight request support and CORS-headers

### DIFF
--- a/docs/reference-configuration.adoc
+++ b/docs/reference-configuration.adoc
@@ -401,6 +401,14 @@ See <<tls>> section
 If set to `true` then Dshackle preserves _batch_ order based on request order.
 Note that latter is ineffective and use this option only when a client cannot reference responses by their IDs.
 
+| `сors-origin`
+|
+| Access-Control-Allow-Origin contents. If empty the header will be omitted in response
+
+| `cors-allowed-headers`
+| `Content-Type`
+| Access-Control-Allow-Headers contents. Takes effect only if сors-origi is present in config
+
 | `routes`
 |
 a| Routing paths for Proxy.

--- a/src/main/kotlin/io/emeraldpay/dshackle/config/ProxyConfig.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/config/ProxyConfig.kt
@@ -55,6 +55,16 @@ open class ProxyConfig {
      */
     var preserveBatchOrder: Boolean = false
 
+    /**
+     * Access-Control-Allow-Origin contents. If null then will omit this header completely
+     */
+    var corsOrigin: String? = null
+
+    /**
+     * Access-Control-Allow-Headers contents. Takes effect only if corsOrigin is not null
+     */
+    var corsAllowedHeaders: String = "Content-Type"
+
     class Route(
         /**
          * URL binding for the route. http://$host:$port/$id

--- a/src/main/kotlin/io/emeraldpay/dshackle/config/ProxyConfigReader.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/config/ProxyConfigReader.kt
@@ -64,6 +64,12 @@ class ProxyConfigReader : YamlConfigReader(), ConfigReader<ProxyConfig> {
         getValueAsBool(input, "preserve-batch-order")?.let {
             config.preserveBatchOrder = it
         }
+        getValueAsString(input, "cors-origin")?.let {
+            config.corsOrigin = it
+        }
+        getValueAsString(input, "cors-allowed-headers")?.let {
+            config.corsAllowedHeaders = it
+        }
         val currentRoutes = HashSet<String>()
         getList<MappingNode>(input, "routes")?.let { routes ->
             config.routes = routes.value.map { route ->

--- a/src/main/kotlin/io/emeraldpay/dshackle/proxy/ProxyServer.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/proxy/ProxyServer.kt
@@ -114,6 +114,7 @@ class ProxyServer(
         config.routes.forEach { routeConfig ->
             // TODO implement a manual handling of the routes and WS upgrade to have a better control over the connection and improve the access logging
             routes.post("/" + routeConfig.id, httpHandler.proxy(routeConfig))
+            routes.options("/" + routeConfig.id, httpHandler.preflight())
             if (config.websocketEnabled && wsHandler != null) {
                 routes.ws("/" + routeConfig.id, wsHandler.proxy(routeConfig))
             }

--- a/src/test/groovy/io/emeraldpay/dshackle/config/ProxyConfigReaderSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/config/ProxyConfigReaderSpec.groovy
@@ -83,6 +83,8 @@ class ProxyConfigReaderSpec extends Specification {
         act.port == 8080
         act.preserveBatchOrder
         act.routes.size() == 2
+        act.corsOrigin == "*"
+        act.corsAllowedHeaders == "Content-Type"
         with(act.routes[0]) {
             id == "ethereum"
             blockchain == Chain.ETHEREUM

--- a/src/test/groovy/io/emeraldpay/dshackle/proxy/ProxyServerSpec.groovy
+++ b/src/test/groovy/io/emeraldpay/dshackle/proxy/ProxyServerSpec.groovy
@@ -31,6 +31,7 @@ class ProxyServerSpec extends Specification {
 
         then:
         1 * routes.post("/test", _)
+        1 * routes.options("/test", _)
         1 * routes.ws("/test", _)
     }
 

--- a/src/test/resources/dshackle-proxy-max.yaml
+++ b/src/test/resources/dshackle-proxy-max.yaml
@@ -3,6 +3,8 @@ proxy:
   host: 0.0.0.0
   port: 8080
   preserve-batch-order: true
+  cors-origin: "*"
+  cors-allowed-headers: "Content-Type"
   routes:
     - id: ethereum
       blockchain: ethereum


### PR DESCRIPTION
Adds preflight request and CORS-headers support for cross-origin requests. 
If enabled will allow requests to proxy from website that is not on the same domain as proxy.