### PR TITLE
ws connection stops working with geth 1.11.0

### DIFF
--- a/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImpl.kt
+++ b/src/main/kotlin/io/emeraldpay/dshackle/upstream/ethereum/WsConnectionImpl.kt
@@ -267,7 +267,7 @@ open class WsConnectionImpl(
         val calls = rpcSend
             .asFlux()
             .map {
-                Unpooled.wrappedBuffer(Global.objectMapper.writeValueAsBytes(it))
+                Unpooled.wrappedBuffer(it.toJson())
             }
 
         return outbound.send(


### PR DESCRIPTION
problem: ws connection stops working with geth 1.11.0 responding: invalid request
solution: enable common JsonRpcRequest serialization, which includes "jsonrpc": "2.0" field